### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Jille/rpcz v0.2.4
 	github.com/spf13/pflag v1.0.5
-	github.com/tetratelabs/wazero v1.0.0-beta.2
+	github.com/tetratelabs/wazero v1.0.0-pre.3
 	go.uber.org/atomic v1.9.0
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
-github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/peasant/peasant.go
+++ b/peasant/peasant.go
@@ -16,12 +16,8 @@ func main() {
 	log.SetFlags(log.Lshortfile)
 	ctx := context.Background()
 
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx)
-
-	if _, err := r.NewModuleBuilder("env").Instantiate(ctx, r); err != nil {
-		log.Panicln(err)
-	}
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().WithStdin(os.Stdin).WithStdout(os.Stdout).WithStderr(os.Stderr).WithArgs("peasant").WithSysWalltime().WithSysNanotime().WithSysNanosleep()
@@ -37,7 +33,7 @@ func main() {
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, bin, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, bin)
 	if err != nil {
 		log.Fatalf("Failed to compile binary: %v", err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

Notably, this improves performance and changes host function syntax.